### PR TITLE
Disable HTTP connection pooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minac"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["yzoug <zoug@protonmail.ch>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To compile it locally, you need [my fork of the `chess` crate](https://github.co
 * This [PR adds support for PGN](https://github.com/jordanbray/chess/pull/71), only change with the original crate.
 * Checkout the branch and put the repo in `../chess-yzoug-fork`: see `Cargo.toml`.
 
-Same with [my fork of the lichess-api crate](https://github.com/yzoug/lichess-api). Both of these projects seem dead.
+Same with [my fork of the lichess-api crate](https://github.com/yzoug/lichess-api).
 
 To use the online mode, a Lichess token with the `challenge:read/write` and `board:play` permissions is needed: write this token in the `token.secret` file at the root of the project, before running `cargo run`.
 
@@ -70,7 +70,7 @@ Feel free to send your enhancements and patches as PRs, or open issues.
 
 Currently working on:
 
-* The game stream is sometimes closed for no reason (either by Lichess, but this doesn't happen with curl, or most likely by my Rust implem and the lichess-api crate). This makes using the program complicated. Main focus is to find the root cause of this and fix it.
+* Stockfish integration
 
 On the hardware side:
 

--- a/src/online/gameplay.rs
+++ b/src/online/gameplay.rs
@@ -28,7 +28,7 @@ pub(crate) async fn online_game() -> Result<()> {
         .expect("Can't read token.secret file: your Lichess token is needed.");
 
     // lichess api and http client creation
-    let client = ClientBuilder::new().build().unwrap();
+    let client = ClientBuilder::new().pool_max_idle_per_host(0).build().unwrap();
     let auth_header = String::from(token).trim().to_string();
     let api = LichessApi::new(client, Some(auth_header));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,26 @@
 use std::io::{stdin,stdout};
 use std::io::Write;
+use crate::online::commands::MoveOption;
 
-pub(crate) fn ask_for_move() -> String {
+pub(crate) fn ask_for_move() -> (String, Option<MoveOption>) {
     println!("Your turn. Enter the SAN move. Example: Nf3");
     print!(">>> ");
     let _ = stdout().flush();
 
-    let mut next_move = String::new();
-    stdin().read_line(&mut next_move)
+    let mut line_parsed = String::new();
+    stdin().read_line(&mut line_parsed)
         .expect("IO Eroor: failed to read line");
 
-    next_move.trim().to_string()
+    let command = line_parsed.trim();
+    let mut option = None;
+
+    if command.ends_with("DRAW") {
+        option = Some(MoveOption::Draw);
+    } else if command == "RESIGN" {
+        option = Some(MoveOption::Resign);
+    }
+
+    (command.replace("DRAW", "").to_string(), option)
 }
 
 pub(crate) fn get_game_mode() -> u8 {


### PR DESCRIPTION
Fixes issues with HTTP requests not being successful because they were dropped (still not 100% sure what the root issue was).

From what I could gather this may be because I use a connection pooled by the reqwest HTTP client after it is closed, and this happens because my tasks all use the same HTTP client concurrently, sometimes from the same thread (since they are Tokio tasks). My limited understanding of how Tokio/hyper works means that this may not be the issue at all.

Anyway, disabling connection pooling when creating my reqwest HTTP client seems to solve the issue.